### PR TITLE
fix: prevent missing plugins from blanking page

### DIFF
--- a/vaso-free/index.html
+++ b/vaso-free/index.html
@@ -1,63 +1,136 @@
-<!DOCTYPE html>
+<!doctype html>
 <html>
   <head>
     <title>Vaso Ecommerce Template</title>
-    <meta charset="utf-8">
-    <meta http-equiv="X-UA-Compatible" content="IE=edge">
-    <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <meta name="format-detection" content="telephone=no">
-    <meta name="apple-mobile-web-app-capable" content="yes">
-    <meta name="author" content="">
-    <meta name="keywords" content="">
-    <meta name="description" content="">
-    <link rel="stylesheet" type="text/css" href="css/vendor.css">
-    <link rel="stylesheet" type="text/css" href="css/bootstrap.min.css">
-    <link rel="stylesheet" type="text/css" href="style.css">
+    <meta charset="utf-8" />
+    <meta http-equiv="X-UA-Compatible" content="IE=edge" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta name="format-detection" content="telephone=no" />
+    <meta name="apple-mobile-web-app-capable" content="yes" />
+    <meta name="author" content="" />
+    <meta name="keywords" content="" />
+    <meta name="description" content="" />
+    <link rel="stylesheet" type="text/css" href="css/vendor.css" />
+    <link rel="stylesheet" type="text/css" href="css/bootstrap.min.css" />
+    <link rel="stylesheet" type="text/css" href="style.css" />
 
-    <link rel="preconnect" href="https://fonts.googleapis.com">
-    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-    <link href="https://fonts.googleapis.com/css2?family=Italiana&family=Mulish:ital,wght@0,200;0,300;0,400;0,500;0,600;0,700;0,800;0,900;0,1000;1,200;1,300;1,400;1,500;1,600;1,700;1,800;1,900;1,1000&display=swap" rel="stylesheet">
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link
+      href="https://fonts.googleapis.com/css2?family=Italiana&amp;family=Mulish:ital,wght@0,200;0,300;0,400;0,500;0,600;0,700;0,800;0,900;0,1000;1,200;1,300;1,400;1,500;1,600;1,700;1,800;1,900;1,1000&amp;display=swap"
+      rel="stylesheet"
+    />
     <!-- script
     ================================================== -->
     <script src="js/modernizr.js"></script>
   </head>
   <body>
-    <svg xmlns="http://www.w3.org/2000/svg" style="display: none;">
-      <symbol xmlns="http://www.w3.org/2000/svg" id="angle-right" viewBox="0 0 32 32">
-        <path fill="currentColor" d="M12.969 4.281L11.53 5.72L21.812 16l-10.28 10.281l1.437 1.438l11-11l.687-.719l-.687-.719z"/>
+    <svg xmlns="http://www.w3.org/2000/svg" style="display: none">
+      <symbol
+        xmlns="http://www.w3.org/2000/svg"
+        id="angle-right"
+        viewBox="0 0 32 32"
+      >
+        <path
+          fill="currentColor"
+          d="M12.969 4.281L11.53 5.72L21.812 16l-10.28 10.281l1.437 1.438l11-11l.687-.719l-.687-.719z"
+        />
       </symbol>
-      <symbol xmlns="http://www.w3.org/2000/svg" id="angle-left" viewBox="0 0 32 32">
-        <path fill="currentColor" d="m19.031 4.281l-11 11l-.687.719l.687.719l11 11l1.438-1.438L10.187 16L20.47 5.719z"/>
+      <symbol
+        xmlns="http://www.w3.org/2000/svg"
+        id="angle-left"
+        viewBox="0 0 32 32"
+      >
+        <path
+          fill="currentColor"
+          d="m19.031 4.281l-11 11l-.687.719l.687.719l11 11l1.438-1.438L10.187 16L20.47 5.719z"
+        />
       </symbol>
-      <symbol xmlns="http://www.w3.org/2000/svg" id="chevron-down" viewBox="0 0 24 24">
-        <path fill="currentColor" d="M7.41 8.58L12 13.17l4.59-4.59L18 10l-6 6l-6-6l1.41-1.42Z"/>
+      <symbol
+        xmlns="http://www.w3.org/2000/svg"
+        id="chevron-down"
+        viewBox="0 0 24 24"
+      >
+        <path
+          fill="currentColor"
+          d="M7.41 8.58L12 13.17l4.59-4.59L18 10l-6 6l-6-6l1.41-1.42Z"
+        />
       </symbol>
-      <symbol xmlns="http://www.w3.org/2000/svg" id="arrow-right" viewBox="0 0 32 32">
-        <path fill="currentColor" d="M18.719 6.781L17.28 8.22L24.063 15H4v2h20.063l-6.782 6.781l1.438 1.438l8.5-8.5l.687-.719l-.687-.719z"/>
+      <symbol
+        xmlns="http://www.w3.org/2000/svg"
+        id="arrow-right"
+        viewBox="0 0 32 32"
+      >
+        <path
+          fill="currentColor"
+          d="M18.719 6.781L17.28 8.22L24.063 15H4v2h20.063l-6.782 6.781l1.438 1.438l8.5-8.5l.687-.719l-.687-.719z"
+        />
       </symbol>
-      <symbol xmlns="http://www.w3.org/2000/svg" id="arrow-left" viewBox="0 0 32 32">
-        <path fill="currentColor" d="m13.281 6.781l-8.5 8.5l-.687.719l.687.719l8.5 8.5l1.438-1.438L7.938 17H28v-2H7.937l6.782-6.781z"/>
+      <symbol
+        xmlns="http://www.w3.org/2000/svg"
+        id="arrow-left"
+        viewBox="0 0 32 32"
+      >
+        <path
+          fill="currentColor"
+          d="m13.281 6.781l-8.5 8.5l-.687.719l.687.719l8.5 8.5l1.438-1.438L7.938 17H28v-2H7.937l6.782-6.781z"
+        />
       </symbol>
       <symbol xmlns="http://www.w3.org/2000/svg" id="play" viewBox="0 0 24 24">
-        <path fill="currentColor" d="M8 5.14v14l11-7l-11-7Z"/>
+        <path fill="currentColor" d="M8 5.14v14l11-7l-11-7Z" />
       </symbol>
-      <symbol xmlns="http://www.w3.org/2000/svg" id="facebook" viewBox="0 0 24 24">
-        <path fill="currentColor" d="M9.198 21.5h4v-8.01h3.604l.396-3.98h-4V7.5a1 1 0 0 1 1-1h3v-4h-3a5 5 0 0 0-5 5v2.01h-2l-.396 3.98h2.396v8.01Z" />
+      <symbol
+        xmlns="http://www.w3.org/2000/svg"
+        id="facebook"
+        viewBox="0 0 24 24"
+      >
+        <path
+          fill="currentColor"
+          d="M9.198 21.5h4v-8.01h3.604l.396-3.98h-4V7.5a1 1 0 0 1 1-1h3v-4h-3a5 5 0 0 0-5 5v2.01h-2l-.396 3.98h2.396v8.01Z"
+        />
       </symbol>
-      <symbol xmlns="http://www.w3.org/2000/svg" id="youtube" viewBox="0 0 32 32">
-        <path fill="currentColor" d="M29.41 9.26a3.5 3.5 0 0 0-2.47-2.47C24.76 6.2 16 6.2 16 6.2s-8.76 0-10.94.59a3.5 3.5 0 0 0-2.47 2.47A36.13 36.13 0 0 0 2 16a36.13 36.13 0 0 0 .59 6.74a3.5 3.5 0 0 0 2.47 2.47c2.18.59 10.94.59 10.94.59s8.76 0 10.94-.59a3.5 3.5 0 0 0 2.47-2.47A36.13 36.13 0 0 0 30 16a36.13 36.13 0 0 0-.59-6.74ZM13.2 20.2v-8.4l7.27 4.2Z" />
+      <symbol
+        xmlns="http://www.w3.org/2000/svg"
+        id="youtube"
+        viewBox="0 0 32 32"
+      >
+        <path
+          fill="currentColor"
+          d="M29.41 9.26a3.5 3.5 0 0 0-2.47-2.47C24.76 6.2 16 6.2 16 6.2s-8.76 0-10.94.59a3.5 3.5 0 0 0-2.47 2.47A36.13 36.13 0 0 0 2 16a36.13 36.13 0 0 0 .59 6.74a3.5 3.5 0 0 0 2.47 2.47c2.18.59 10.94.59 10.94.59s8.76 0 10.94-.59a3.5 3.5 0 0 0 2.47-2.47A36.13 36.13 0 0 0 30 16a36.13 36.13 0 0 0-.59-6.74ZM13.2 20.2v-8.4l7.27 4.2Z"
+        />
       </symbol>
-      <symbol xmlns="http://www.w3.org/2000/svg" id="twitter" viewBox="0 0 256 256">
-        <path fill="currentColor" d="m245.66 77.66l-29.9 29.9C209.72 177.58 150.67 232 80 232c-14.52 0-26.49-2.3-35.58-6.84c-7.33-3.67-10.33-7.6-11.08-8.72a8 8 0 0 1 3.85-11.93c.26-.1 24.24-9.31 39.47-26.84a110.93 110.93 0 0 1-21.88-24.2c-12.4-18.41-26.28-50.39-22-98.18a8 8 0 0 1 13.65-4.92c.35.35 33.28 33.1 73.54 43.72V88a47.87 47.87 0 0 1 14.36-34.3A46.87 46.87 0 0 1 168.1 40a48.66 48.66 0 0 1 41.47 24H240a8 8 0 0 1 5.66 13.66Z" />
+      <symbol
+        xmlns="http://www.w3.org/2000/svg"
+        id="twitter"
+        viewBox="0 0 256 256"
+      >
+        <path
+          fill="currentColor"
+          d="m245.66 77.66l-29.9 29.9C209.72 177.58 150.67 232 80 232c-14.52 0-26.49-2.3-35.58-6.84c-7.33-3.67-10.33-7.6-11.08-8.72a8 8 0 0 1 3.85-11.93c.26-.1 24.24-9.31 39.47-26.84a110.93 110.93 0 0 1-21.88-24.2c-12.4-18.41-26.28-50.39-22-98.18a8 8 0 0 1 13.65-4.92c.35.35 33.28 33.1 73.54 43.72V88a47.87 47.87 0 0 1 14.36-34.3A46.87 46.87 0 0 1 168.1 40a48.66 48.66 0 0 1 41.47 24H240a8 8 0 0 1 5.66 13.66Z"
+        />
       </symbol>
-      <symbol xmlns="http://www.w3.org/2000/svg" id="instagram" viewBox="0 0 256 256">
-        <path fill="currentColor" d="M128 80a48 48 0 1 0 48 48a48.05 48.05 0 0 0-48-48Zm0 80a32 32 0 1 1 32-32a32 32 0 0 1-32 32Zm48-136H80a56.06 56.06 0 0 0-56 56v96a56.06 56.06 0 0 0 56 56h96a56.06 56.06 0 0 0 56-56V80a56.06 56.06 0 0 0-56-56Zm40 152a40 40 0 0 1-40 40H80a40 40 0 0 1-40-40V80a40 40 0 0 1 40-40h96a40 40 0 0 1 40 40ZM192 76a12 12 0 1 1-12-12a12 12 0 0 1 12 12Z" />
+      <symbol
+        xmlns="http://www.w3.org/2000/svg"
+        id="instagram"
+        viewBox="0 0 256 256"
+      >
+        <path
+          fill="currentColor"
+          d="M128 80a48 48 0 1 0 48 48a48.05 48.05 0 0 0-48-48Zm0 80a32 32 0 1 1 32-32a32 32 0 0 1-32 32Zm48-136H80a56.06 56.06 0 0 0-56 56v96a56.06 56.06 0 0 0 56 56h96a56.06 56.06 0 0 0 56-56V80a56.06 56.06 0 0 0-56-56Zm40 152a40 40 0 0 1-40 40H80a40 40 0 0 1-40-40V80a40 40 0 0 1 40-40h96a40 40 0 0 1 40 40ZM192 76a12 12 0 1 1-12-12a12 12 0 0 1 12 12Z"
+        />
       </symbol>
-      <symbol xmlns="http://www.w3.org/2000/svg" id="linkedin" viewBox="0 0 24 24">
-        <path fill="currentColor" d="M6.94 5a2 2 0 1 1-4-.002a2 2 0 0 1 4 .002zM7 8.48H3V21h4V8.48zm6.32 0H9.34V21h3.94v-6.57c0-3.66 4.77-4 4.77 0V21H22v-7.93c0-6.17-7.06-5.94-8.72-2.91l.04-1.68z" />
+      <symbol
+        xmlns="http://www.w3.org/2000/svg"
+        id="linkedin"
+        viewBox="0 0 24 24"
+      >
+        <path
+          fill="currentColor"
+          d="M6.94 5a2 2 0 1 1-4-.002a2 2 0 0 1 4 .002zM7 8.48H3V21h4V8.48zm6.32 0H9.34V21h3.94v-6.57c0-3.66 4.77-4 4.77 0V21H22v-7.93c0-6.17-7.06-5.94-8.72-2.91l.04-1.68z"
+        />
       </symbol>
     </svg>
-    
+
     <div id="preloader">
       <div id="loader"></div>
     </div>
@@ -67,24 +140,57 @@
       <div class="container">
         <div class="row">
           <div class="offset-md-2 col-md-8">
-            <span class="title-accent fs-6 text-uppercase" data-aos="fade" data-aos-easing="ease-in" data-aos-duration="1000" data-aos-once="true">About us</span>
-            <h3 class="py-3" data-aos="fade" data-aos-easing="ease-in" data-aos-duration="1500" data-aos-once="true">Vaso is the only best online store for varieties of collection of clean and beautiful vases.</h3>
-            <p data-aos="fade" data-aos-easing="ease-in" data-aos-duration="1800" data-aos-once="true">Et id sapien id enim, sit tempor cursus elit, fusce. Nunc tristique facilisis consectetur at vivamus ut porta porta. Ut nisl, tortor, aliquam blandit vitae vehicula vivamus leo nullam urna, scelerisque unc lectus phasellus adipiscing arcu. Tristique facilisis nunc consectetur at tempor cursusut porta.</p>
+            <span
+              class="title-accent fs-6 text-uppercase"
+              data-aos="fade"
+              data-aos-easing="ease-in"
+              data-aos-duration="1000"
+              data-aos-once="true"
+              >About us</span
+            >
+            <h3
+              class="py-3"
+              data-aos="fade"
+              data-aos-easing="ease-in"
+              data-aos-duration="1500"
+              data-aos-once="true"
+            >
+              Vaso is the only best online store for varieties of collection of
+              clean and beautiful vases.
+            </h3>
+            <p
+              data-aos="fade"
+              data-aos-easing="ease-in"
+              data-aos-duration="1800"
+              data-aos-once="true"
+            >
+              Et id sapien id enim, sit tempor cursus elit, fusce. Nunc
+              tristique facilisis consectetur at vivamus ut porta porta. Ut
+              nisl, tortor, aliquam blandit vitae vehicula vivamus leo nullam
+              urna, scelerisque unc lectus phasellus adipiscing arcu. Tristique
+              facilisis nunc consectetur at tempor cursusut porta.
+            </p>
           </div>
         </div>
       </div>
     </section-wrapper>
     <section-wrapper id="products" class="product-store position-relative">
-      <div class="container display-header d-flex flex-wrap justify-content-between pb-4">
+      <div
+        class="container display-header d-flex flex-wrap justify-content-between pb-4"
+      >
         <h3 class="mt-3">Best selling Items</h3>
         <div class="btn-right d-flex flex-wrap align-items-center">
           <a href="shop.html" class="btn me-5">View all items</a>
           <div class="swiper-buttons">
             <button class="swiper-prev product-carousel-prev me-2">
-              <svg width="41" height="41"><use xlink:href="#angle-left"></use></svg>
+              <svg width="41" height="41">
+                <use xlink:href="#angle-left"></use>
+              </svg>
             </button>
             <button class="swiper-next product-carousel-next">
-              <svg width="41" height="41"><use xlink:href="#angle-right"></use></svg>
+              <svg width="41" height="41">
+                <use xlink:href="#angle-right"></use>
+              </svg>
             </button>
           </div>
         </div>
@@ -94,7 +200,11 @@
           <div class="swiper-slide">
             <div class="product-card position-relative">
               <div class="image-holder zoom-effect">
-                <img src="images/product-item1.jpg" alt="product-item" class="img-fluid zoom-in">
+                <img
+                  src="images/product-item1.jpg"
+                  alt="product-item"
+                  class="img-fluid zoom-in"
+                />
                 <div class="cart-concern position-absolute">
                   <div class="cart-button">
                     <a href="#" class="btn">Add to Cart</a>
@@ -112,7 +222,11 @@
           <div class="swiper-slide">
             <div class="product-card position-relative">
               <div class="image-holder zoom-effect">
-                <img src="images/product-item2.jpg" alt="product-item" class="img-fluid zoom-in">
+                <img
+                  src="images/product-item2.jpg"
+                  alt="product-item"
+                  class="img-fluid zoom-in"
+                />
                 <div class="cart-concern position-absolute">
                   <div class="cart-button">
                     <a href="#" class="btn">Add to Cart</a>
@@ -130,7 +244,11 @@
           <div class="swiper-slide">
             <div class="product-card position-relative">
               <div class="image-holder zoom-effect">
-                <img src="images/product-item3.jpg" alt="product-item" class="img-fluid zoom-in">
+                <img
+                  src="images/product-item3.jpg"
+                  alt="product-item"
+                  class="img-fluid zoom-in"
+                />
                 <div class="cart-concern position-absolute">
                   <div class="cart-button">
                     <a href="#" class="btn">Add to Cart</a>
@@ -148,7 +266,11 @@
           <div class="swiper-slide">
             <div class="product-card position-relative">
               <div class="image-holder zoom-effect">
-                <img src="images/product-item4.jpg" alt="product-item" class="img-fluid zoom-in">
+                <img
+                  src="images/product-item4.jpg"
+                  alt="product-item"
+                  class="img-fluid zoom-in"
+                />
                 <div class="cart-concern position-absolute">
                   <div class="cart-button">
                     <a href="#" class="btn">Add to Cart</a>
@@ -166,7 +288,11 @@
           <div class="swiper-slide">
             <div class="product-card position-relative">
               <div class="image-holder zoom-effect">
-                <img src="images/product-item5.jpg" alt="product-item" class="img-fluid zoom-in">
+                <img
+                  src="images/product-item5.jpg"
+                  alt="product-item"
+                  class="img-fluid zoom-in"
+                />
                 <div class="cart-concern position-absolute">
                   <div class="cart-button">
                     <a href="#" class="btn">Add to Cart</a>
@@ -184,7 +310,11 @@
           <div class="swiper-slide">
             <div class="product-card position-relative">
               <div class="image-holder zoom-effect">
-                <img src="images/product-item2.jpg" alt="product-item" class="img-fluid zoom-in">
+                <img
+                  src="images/product-item2.jpg"
+                  alt="product-item"
+                  class="img-fluid zoom-in"
+                />
                 <div class="cart-concern position-absolute">
                   <div class="cart-button">
                     <a href="#" class="btn">Add to Cart</a>
@@ -202,7 +332,11 @@
           <div class="swiper-slide">
             <div class="product-card position-relative">
               <div class="image-holder zoom-effect">
-                <img src="images/product-item4.jpg" alt="product-item" class="img-fluid zoom-in">
+                <img
+                  src="images/product-item4.jpg"
+                  alt="product-item"
+                  class="img-fluid zoom-in"
+                />
                 <div class="cart-concern position-absolute">
                   <div class="cart-button">
                     <a href="#" class="btn">Add to Cart</a>
@@ -220,7 +354,11 @@
           <div class="swiper-slide">
             <div class="product-card position-relative">
               <div class="image-holder zoom-effect">
-                <img src="images/product-item3.jpg" alt="product-item" class="img-fluid zoom-in">
+                <img
+                  src="images/product-item3.jpg"
+                  alt="product-item"
+                  class="img-fluid zoom-in"
+                />
                 <div class="cart-concern position-absolute">
                   <div class="cart-button">
                     <a href="#" class="btn">Add to Cart</a>
@@ -242,44 +380,95 @@
       <div class="container">
         <div class="row">
           <div class="offset-md-2 col-md-8">
-            <h3 class="text-center mb-5" data-aos="fade" data-aos-easing="ease-in" data-aos-duration="1000" data-aos-once="true">What our customers says</h3>
-            <div class="review-content position-relative" data-aos="fade" data-aos-easing="ease-in" data-aos-duration="1500" data-aos-once="true">
+            <h3
+              class="text-center mb-5"
+              data-aos="fade"
+              data-aos-easing="ease-in"
+              data-aos-duration="1000"
+              data-aos-once="true"
+            >
+              What our customers says
+            </h3>
+            <div
+              class="review-content position-relative"
+              data-aos="fade"
+              data-aos-easing="ease-in"
+              data-aos-duration="1500"
+              data-aos-once="true"
+            >
               <div class="swiper testimonial-swiper">
                 <div class="swiper-wrapper">
-                  <div class="swiper-slide text-center d-flex justify-content-center">
+                  <div
+                    class="swiper-slide text-center d-flex justify-content-center"
+                  >
                     <div class="review-item">
-                      <blockquote class="fs-1 fw-light">“A pellen tesque pretium feugiat vel morbi sagittis lorem habi tasse cursus. Suspen dise tempus oncu enim pellen tesque este pretium in neque, elit morbi sagittis lorem habi mattis.”</blockquote>
+                      <blockquote class="fs-1 fw-light">
+                        “A pellen tesque pretium feugiat vel morbi sagittis
+                        lorem habi tasse cursus. Suspen dise tempus oncu enim
+                        pellen tesque este pretium in neque, elit morbi sagittis
+                        lorem habi mattis.”
+                      </blockquote>
                       <div class="author-detail">
-                        <div class="name fw-bold text-uppercase pt-2">Anna garcia</div>
+                        <div class="name fw-bold text-uppercase pt-2">
+                          Anna garcia
+                        </div>
                       </div>
                     </div>
                   </div>
-                  <div class="swiper-slide text-center d-flex justify-content-center">
+                  <div
+                    class="swiper-slide text-center d-flex justify-content-center"
+                  >
                     <div class="review-item">
-                      <blockquote class="fs-1 fw-light">“A pellen tesque pretium feugiat vel morbi sagittis lorem habi tasse cursus. Suspen dise tempus oncu enim pellen tesque este pretium in neque, elit morbi sagittis lorem habi mattis.”</blockquote>
+                      <blockquote class="fs-1 fw-light">
+                        “A pellen tesque pretium feugiat vel morbi sagittis
+                        lorem habi tasse cursus. Suspen dise tempus oncu enim
+                        pellen tesque este pretium in neque, elit morbi sagittis
+                        lorem habi mattis.”
+                      </blockquote>
                       <div class="author-detail">
-                        <div class="name fw-bold text-uppercase pt-2">Anna garcia</div>
+                        <div class="name fw-bold text-uppercase pt-2">
+                          Anna garcia
+                        </div>
                       </div>
                     </div>
                   </div>
-                  <div class="swiper-slide text-center d-flex justify-content-center">
+                  <div
+                    class="swiper-slide text-center d-flex justify-content-center"
+                  >
                     <div class="review-item">
-                      <blockquote class="fs-1 fw-light">“A pellen tesque pretium feugiat vel morbi sagittis lorem habi tasse cursus. Suspen dise tempus oncu enim pellen tesque este pretium in neque, elit morbi sagittis lorem habi mattis.”</blockquote>
+                      <blockquote class="fs-1 fw-light">
+                        “A pellen tesque pretium feugiat vel morbi sagittis
+                        lorem habi tasse cursus. Suspen dise tempus oncu enim
+                        pellen tesque este pretium in neque, elit morbi sagittis
+                        lorem habi mattis.”
+                      </blockquote>
                       <div class="author-detail">
-                        <div class="name fw-bold text-uppercase pt-2">Anna garcia</div>
+                        <div class="name fw-bold text-uppercase pt-2">
+                          Anna garcia
+                        </div>
                       </div>
                     </div>
                   </div>
                 </div>
               </div>
             </div>
-            <div class="swiper-buttons text-center mt-5" data-aos="fade" data-aos-easing="ease-in" data-aos-duration="1800" data-aos-once="true">
+            <div
+              class="swiper-buttons text-center mt-5"
+              data-aos="fade"
+              data-aos-easing="ease-in"
+              data-aos-duration="1800"
+              data-aos-once="true"
+            >
               <button class="swiper-prev testimonial-arrow-prev me-2">
-                <svg width="41" height="41"><use xlink:href="#arrow-left"></use></svg>
+                <svg width="41" height="41">
+                  <use xlink:href="#arrow-left"></use>
+                </svg>
               </button>
               <span>|</span>
               <button class="swiper-next testimonial-arrow-next ms-2">
-                <svg width="41" height="41"><use xlink:href="#arrow-right"></use></svg>
+                <svg width="41" height="41">
+                  <use xlink:href="#arrow-right"></use>
+                </svg>
               </button>
             </div>
           </div>
@@ -287,11 +476,30 @@
       </div>
     </section-wrapper>
     <section-wrapper id="our-video">
-      <div class="video-section jarallax d-flex align-items-center justify-content-center" style="background: url(images/video-image.jpg) no-repeat;">
+      <div
+        class="video-section jarallax d-flex align-items-center justify-content-center"
+        style="background: url(images/video-image.jpg) no-repeat"
+      >
         <div class="video-player text-center">
-          <a type="button" data-bs-toggle="modal" data-src="https://www.youtube.com/embed/W_tIumKa8VY" data-bs-target="#myModal" class="play-btn position-relative">
-            <svg class="position-absolute top-0 bottom-0 start-0 end-0 m-auto" width="41" height="41"><use xlink:href="#play"></use></svg>
-            <img src="images/text-pattern.png" alt="pattern" class="text-pattern">
+          <a
+            type="button"
+            data-bs-toggle="modal"
+            data-src="https://www.youtube.com/embed/W_tIumKa8VY"
+            data-bs-target="#myModal"
+            class="play-btn position-relative"
+          >
+            <svg
+              class="position-absolute top-0 bottom-0 start-0 end-0 m-auto"
+              width="41"
+              height="41"
+            >
+              <use xlink:href="#play"></use>
+            </svg>
+            <img
+              src="images/text-pattern.png"
+              alt="pattern"
+              class="text-pattern"
+            />
           </a>
         </div>
       </div>
@@ -300,93 +508,234 @@
       <div class="container">
         <div class="row">
           <div class="offset-md-2 col-md-8">
-            <h3 class="text-center mb-5" data-aos="fade" data-aos-easing="ease-in" data-aos-duration="1000" data-aos-once="true">Some FAQs</h3>
-            <div class="accordion accordion-flush" id="accordionFlush" data-aos="fade" data-aos-easing="ease-in" data-aos-duration="1500" data-aos-once="true">
+            <h3
+              class="text-center mb-5"
+              data-aos="fade"
+              data-aos-easing="ease-in"
+              data-aos-duration="1000"
+              data-aos-once="true"
+            >
+              Some FAQs
+            </h3>
+            <div
+              class="accordion accordion-flush"
+              id="accordionFlush"
+              data-aos="fade"
+              data-aos-easing="ease-in"
+              data-aos-duration="1500"
+              data-aos-once="true"
+            >
               <div class="accordion-item">
                 <h4 class="accordion-header" id="flush-headingOne3">
-                  <button class="accordion-button collapsed" type="button" data-bs-toggle="collapse" data-bs-target="#flush-collapseOne" aria-expanded="true" aria-controls="flush-collapseOne">
+                  <button
+                    class="accordion-button collapsed"
+                    type="button"
+                    data-bs-toggle="collapse"
+                    data-bs-target="#flush-collapseOne"
+                    aria-expanded="true"
+                    aria-controls="flush-collapseOne"
+                  >
                     I got my vase but some items are broken, what to do?
                   </button>
                 </h4>
-                <div id="flush-collapseOne" class="accordion-collapse collapse" aria-labelledby="flush-headingOne" data-bs-parent="#accordionFlushExample">
+                <div
+                  id="flush-collapseOne"
+                  class="accordion-collapse collapse"
+                  aria-labelledby="flush-headingOne"
+                  data-bs-parent="#accordionFlushExample"
+                >
                   <div class="accordion-body">
-                    <p>Et id sapien id enim, sit tempor cursus elit, fusce. Nunc tristique facilisis consectetur at vivamus ut porta porta aliquam blandit vitae vehicula leo nullam urna, scelerisque unc lectus.</p>
+                    <p>
+                      Et id sapien id enim, sit tempor cursus elit, fusce. Nunc
+                      tristique facilisis consectetur at vivamus ut porta porta
+                      aliquam blandit vitae vehicula leo nullam urna,
+                      scelerisque unc lectus.
+                    </p>
                   </div>
                 </div>
               </div>
-      
+
               <div class="accordion-item">
                 <h4 class="accordion-header" id="flush-headingTwo3">
-                  <button class="accordion-button collapsed" type="button" data-bs-toggle="collapse" data-bs-target="#flush-collapseTwo" aria-expanded="true" aria-controls="flush-collapseTwo">
+                  <button
+                    class="accordion-button collapsed"
+                    type="button"
+                    data-bs-toggle="collapse"
+                    data-bs-target="#flush-collapseTwo"
+                    aria-expanded="true"
+                    aria-controls="flush-collapseTwo"
+                  >
                     Can i return them if I don't like the items I bought?
                   </button>
                 </h4>
-                <div id="flush-collapseTwo" class="accordion-collapse collapse" aria-labelledby="flush-headingTwo" data-bs-parent="#accordionFlushExample">
+                <div
+                  id="flush-collapseTwo"
+                  class="accordion-collapse collapse"
+                  aria-labelledby="flush-headingTwo"
+                  data-bs-parent="#accordionFlushExample"
+                >
                   <div class="accordion-body">
-                    <p>Et id sapien id enim, sit tempor cursus elit, fusce. Nunc tristique facilisis consectetur at vivamus ut porta porta aliquam blandit vitae vehicula leo nullam urna, scelerisque unc lectus.</p>
+                    <p>
+                      Et id sapien id enim, sit tempor cursus elit, fusce. Nunc
+                      tristique facilisis consectetur at vivamus ut porta porta
+                      aliquam blandit vitae vehicula leo nullam urna,
+                      scelerisque unc lectus.
+                    </p>
                   </div>
                 </div>
               </div>
-      
+
               <div class="accordion-item">
                 <h4 class="accordion-header" id="flush-headingThree3">
-                  <button class="accordion-button collapsed" type="button" data-bs-toggle="collapse" data-bs-target="#flush-collapseThree" aria-expanded="true" aria-controls="flush-collapseThree">
+                  <button
+                    class="accordion-button collapsed"
+                    type="button"
+                    data-bs-toggle="collapse"
+                    data-bs-target="#flush-collapseThree"
+                    aria-expanded="true"
+                    aria-controls="flush-collapseThree"
+                  >
                     Will we get discount if we will order many vase?
                   </button>
                 </h4>
-                <div id="flush-collapseThree" class="accordion-collapse collapse" aria-labelledby="flush-headingThree" data-bs-parent="#accordionFlushExample">
+                <div
+                  id="flush-collapseThree"
+                  class="accordion-collapse collapse"
+                  aria-labelledby="flush-headingThree"
+                  data-bs-parent="#accordionFlushExample"
+                >
                   <div class="accordion-body">
-                    <p>Et id sapien id enim, sit tempor cursus elit, fusce. Nunc tristique facilisis consectetur at vivamus ut porta porta aliquam blandit vitae vehicula leo nullam urna, scelerisque unc lectus.</p>
+                    <p>
+                      Et id sapien id enim, sit tempor cursus elit, fusce. Nunc
+                      tristique facilisis consectetur at vivamus ut porta porta
+                      aliquam blandit vitae vehicula leo nullam urna,
+                      scelerisque unc lectus.
+                    </p>
                   </div>
                 </div>
               </div>
-      
+
               <div class="accordion-item">
                 <h4 class="accordion-header" id="flush-headingFour3">
-                  <button class="accordion-button collapsed" type="button" data-bs-toggle="collapse" data-bs-target="#flush-collapseFour" aria-expanded="true" aria-controls="flush-collapseFour">
+                  <button
+                    class="accordion-button collapsed"
+                    type="button"
+                    data-bs-toggle="collapse"
+                    data-bs-target="#flush-collapseFour"
+                    aria-expanded="true"
+                    aria-controls="flush-collapseFour"
+                  >
                     Are there refunds for sale items or some special orders?
                   </button>
                 </h4>
-                <div id="flush-collapseFour" class="accordion-collapse collapse" aria-labelledby="flush-headingFour" data-bs-parent="#accordionFlushExample">
+                <div
+                  id="flush-collapseFour"
+                  class="accordion-collapse collapse"
+                  aria-labelledby="flush-headingFour"
+                  data-bs-parent="#accordionFlushExample"
+                >
                   <div class="accordion-body">
-                    <p>Et id sapien id enim, sit tempor cursus elit, fusce. Nunc tristique facilisis consectetur at vivamus ut porta porta aliquam blandit vitae vehicula leo nullam urna, scelerisque unc lectus.</p>
+                    <p>
+                      Et id sapien id enim, sit tempor cursus elit, fusce. Nunc
+                      tristique facilisis consectetur at vivamus ut porta porta
+                      aliquam blandit vitae vehicula leo nullam urna,
+                      scelerisque unc lectus.
+                    </p>
                   </div>
                 </div>
               </div>
-      
+
               <div class="accordion-item">
                 <h4 class="accordion-header" id="flush-headingFive3">
-                  <button class="accordion-button collapsed" type="button" data-bs-toggle="collapse" data-bs-target="#flush-collapseFive" aria-expanded="true" aria-controls="flush-collapseFive">
+                  <button
+                    class="accordion-button collapsed"
+                    type="button"
+                    data-bs-toggle="collapse"
+                    data-bs-target="#flush-collapseFive"
+                    aria-expanded="true"
+                    aria-controls="flush-collapseFive"
+                  >
                     How long will it take to get my first order?
                   </button>
                 </h4>
-                <div id="flush-collapseFive" class="accordion-collapse collapse" aria-labelledby="flush-headingFive" data-bs-parent="#accordionFlushExample">
+                <div
+                  id="flush-collapseFive"
+                  class="accordion-collapse collapse"
+                  aria-labelledby="flush-headingFive"
+                  data-bs-parent="#accordionFlushExample"
+                >
                   <div class="accordion-body">
-                    <p>Et id sapien id enim, sit tempor cursus elit, fusce. Nunc tristique facilisis consectetur at vivamus ut porta porta aliquam blandit vitae vehicula leo nullam urna, scelerisque unc lectus.</p>
+                    <p>
+                      Et id sapien id enim, sit tempor cursus elit, fusce. Nunc
+                      tristique facilisis consectetur at vivamus ut porta porta
+                      aliquam blandit vitae vehicula leo nullam urna,
+                      scelerisque unc lectus.
+                    </p>
                   </div>
                 </div>
               </div>
-      
-            </div>      
+            </div>
           </div>
         </div>
       </div>
-    </section-wrapper>    
+    </section-wrapper>
     <section-wrapper id="banner" data-aos="fade" data-aos-once="true">
-      <div class="banner-content-1 position-relative" style="background:url('images/banner-img1.jpg') no-repeat left; background-size: cover; height: 100%;">
-        <div class="banner-content-text position-absolute" data-aos="fade" data-aos-delay="1000" data-aos-easing="ease-in" data-aos-duration="1000" data-aos-once="true">
+      <div
+        class="banner-content-1 position-relative"
+        style="
+          background: url(&quot;images/banner-img1.jpg&quot;) no-repeat left;
+          background-size: cover;
+          height: 100%;
+        "
+      >
+        <div
+          class="banner-content-text position-absolute"
+          data-aos="fade"
+          data-aos-delay="1000"
+          data-aos-easing="ease-in"
+          data-aos-duration="1000"
+          data-aos-once="true"
+        >
           <h2>Old handmade</h2>
           <a href="shop.html" class="btn">Shop it now</a>
         </div>
       </div>
-      <div class="banner-content-2 position-relative" style="background:url('images/banner-img2.jpg') no-repeat left; background-size: cover; height: 100%;">
-        <div class="banner-content-text position-absolute" data-aos="fade" data-aos-delay="1000" data-aos-easing="ease-in" data-aos-duration="1000" data-aos-once="true">
+      <div
+        class="banner-content-2 position-relative"
+        style="
+          background: url(&quot;images/banner-img2.jpg&quot;) no-repeat left;
+          background-size: cover;
+          height: 100%;
+        "
+      >
+        <div
+          class="banner-content-text position-absolute"
+          data-aos="fade"
+          data-aos-delay="1000"
+          data-aos-easing="ease-in"
+          data-aos-duration="1000"
+          data-aos-once="true"
+        >
           <h2>Double handle</h2>
           <a href="shop.html" class="btn">Shop collection</a>
         </div>
       </div>
-      <div class="banner-content-3 position-relative" style="background:url('images/banner-img3.jpg') no-repeat left; background-size: cover; height: 100%;">
-        <div class="banner-content-text position-absolute" data-aos="fade" data-aos-delay="1000" data-aos-easing="ease-in" data-aos-duration="1000" data-aos-once="true">
+      <div
+        class="banner-content-3 position-relative"
+        style="
+          background: url(&quot;images/banner-img3.jpg&quot;) no-repeat left;
+          background-size: cover;
+          height: 100%;
+        "
+      >
+        <div
+          class="banner-content-text position-absolute"
+          data-aos="fade"
+          data-aos-delay="1000"
+          data-aos-easing="ease-in"
+          data-aos-duration="1000"
+          data-aos-once="true"
+        >
           <h2>Pumpers</h2>
           <a href="shop.html" class="btn">Shop collection</a>
         </div>
@@ -394,26 +743,44 @@
     </section-wrapper>
     <site-footer></site-footer>
     <!-- Video Popup -->
-    <div class="modal fade" id="myModal" tabindex="-1" role="dialog" aria-labelledby="exampleModalLabel" aria-hidden="true">
+    <div
+      class="modal fade"
+      id="myModal"
+      tabindex="-1"
+      role="dialog"
+      aria-labelledby="exampleModalLabel"
+      aria-hidden="true"
+    >
       <div class="modal-dialog" role="document">
-
-          <div class="modal-content">
-            
-              <div class="modal-body">
-                  <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"><svg class="bi" width="40" height="40"><use xlink:href="#close-sharp"></use></svg></button>
-                  <div class="ratio ratio-16x9">
-                    <iframe class="embed-responsive-item" src="" id="video"  allowscriptaccess="always" allow="autoplay"></iframe>
-                  </div>
-              </div>
-
+        <div class="modal-content">
+          <div class="modal-body">
+            <button
+              type="button"
+              class="btn-close"
+              data-bs-dismiss="modal"
+              aria-label="Close"
+            >
+              <svg class="bi" width="40" height="40">
+                <use xlink:href="#close-sharp"></use>
+              </svg>
+            </button>
+            <div class="ratio ratio-16x9">
+              <iframe
+                class="embed-responsive-item"
+                src=""
+                id="video"
+                allowscriptaccess="always"
+                allow="autoplay"
+              ></iframe>
+            </div>
           </div>
-
+        </div>
       </div>
     </div>
     <script src="js/jquery-1.11.0.min.js"></script>
     <script type="text/javascript" src="js/bootstrap.bundle.min.js"></script>
     <script type="text/javascript" src="js/plugins.js"></script>
-      <script type="text/javascript" src="js/components.js"></script>
+    <script type="text/javascript" src="js/components.js"></script>
     <script type="text/javascript" src="js/script.js"></script>
   </body>
 </html>

--- a/vaso-free/js/script.js
+++ b/vaso-free/js/script.js
@@ -1,76 +1,74 @@
-(function($) {
+(function ($) {
+  "use strict";
 
-    "use strict";
+  //  Header sticky
+  const headerSticky = function () {
+    const header = document.querySelector("#header");
+    if (!header) return;
+    const trigHeight = 1;
 
-    //  Header sticky
-    const headerSticky = function() {
-      const header = document.querySelector('#header');
-      if (!header) return;      
-      const trigHeight = 1;
+    window.addEventListener("scroll", function () {
+      let tj = window.scrollY;
 
-      window.addEventListener('scroll', function () {
-          let tj = window.scrollY;
+      if (tj > trigHeight) {
+        header.classList.add("sticky");
+      } else {
+        header.classList.remove("sticky");
+      }
+    });
+  };
 
-          if (tj > trigHeight) {
-              header.classList.add('sticky');
-          } else {
-              header.classList.remove('sticky');
-          }
-      });
-    };
+  // init jarallax parallax
+  var initJarallax = function () {
+    if (!window.jarallax) return;
+    jarallax(document.querySelectorAll(".jarallax"));
 
-    // init jarallax parallax
-    var initJarallax = function() {
-      jarallax(document.querySelectorAll(".jarallax"));
+    jarallax(document.querySelectorAll(".jarallax-img"), {
+      keepImg: true,
+    });
+  };
 
-      jarallax(document.querySelectorAll(".jarallax-img"), {
-        keepImg: true,
-      });
-    }
+  // product quantity
+  var initProductQty = function () {
+    $(".product-qty").each(function () {
+      var $el_product = $(this);
+      var quantity = 0;
 
-    // product quantity
-    var initProductQty = function(){
-
-      $('.product-qty').each(function(){
-
-        var $el_product = $(this);
-        var quantity = 0;
-
-        $el_product.find('.quantity-right-plus').click(function(e){
-            e.preventDefault();
-            var quantity = parseInt($el_product.find('#quantity').val());
-            $el_product.find('#quantity').val(quantity + 1);
-        });
-
-        $el_product.find('.quantity-left-minus').click(function(e){
-            e.preventDefault();
-            var quantity = parseInt($el_product.find('#quantity').val());
-            if(quantity>0){
-              $el_product.find('#quantity').val(quantity - 1);
-            }
-        });
-
+      $el_product.find(".quantity-right-plus").click(function (e) {
+        e.preventDefault();
+        var quantity = parseInt($el_product.find("#quantity").val());
+        $el_product.find("#quantity").val(quantity + 1);
       });
 
-    }
+      $el_product.find(".quantity-left-minus").click(function (e) {
+        e.preventDefault();
+        var quantity = parseInt($el_product.find("#quantity").val());
+        if (quantity > 0) {
+          $el_product.find("#quantity").val(quantity - 1);
+        }
+      });
+    });
+  };
 
-    $(document).ready(function() {
-      
-      /* Video */
-      var $videoSrc;  
-        $('.play-btn').click(function() {
-          $videoSrc = $(this).data( "src" );
-        });
+  $(document).ready(function () {
+    /* Video */
+    var $videoSrc;
+    $(".play-btn").click(function () {
+      $videoSrc = $(this).data("src");
+    });
 
-        $('#myModal').on('shown.bs.modal', function (e) {
+    $("#myModal").on("shown.bs.modal", function (e) {
+      $("#video").attr(
+        "src",
+        $videoSrc + "?autoplay=1&amp;modestbranding=1&amp;showinfo=0",
+      );
+    });
 
-        $("#video").attr('src',$videoSrc + "?autoplay=1&amp;modestbranding=1&amp;showinfo=0" ); 
-      })
+    $("#myModal").on("hide.bs.modal", function (e) {
+      $("#video").attr("src", $videoSrc);
+    });
 
-      $('#myModal').on('hide.bs.modal', function (e) {
-        $("#video").attr('src',$videoSrc); 
-      })
-
+    if (window.Swiper) {
       var swiper = new Swiper(".main-swiper", {
         loop: true,
         speed: 800,
@@ -92,7 +90,6 @@
           clickable: true,
         },
       });
-      
       var swiper = new Swiper(".product-swiper", {
         speed: 1000,
         spaceBetween: 20,
@@ -114,10 +111,9 @@
           1200: {
             slidesPerView: 5,
             spaceBetween: 20,
-          }
+          },
         },
-      }); 
-
+      });
       var swiper = new Swiper(".testimonial-swiper", {
         speed: 1000,
         navigation: {
@@ -125,28 +121,28 @@
           prevEl: ".testimonial-arrow-prev",
         },
       });
-
       var thumb_slider = new Swiper(".thumb-swiper", {
         slidesPerView: 1,
       });
       var large_slider = new Swiper(".large-swiper", {
         spaceBetween: 10,
-        effect: 'fade',
+        effect: "fade",
         thumbs: {
           swiper: thumb_slider,
         },
       });
+    }
 
-      headerSticky();
-      initJarallax();
-      initProductQty();
+    headerSticky();
+    initJarallax();
+    initProductQty();
+    if (window.AOS) {
       AOS.init();
-      
-    }); // End of a document ready
+    }
+  }); // End of a document ready
 
-    window.addEventListener("load", function () {
-      const preloader = document.getElementById("preloader");
-      preloader.classList.add("hide-preloader");      
-    });
-
+  window.addEventListener("load", function () {
+    const preloader = document.getElementById("preloader");
+    preloader.classList.add("hide-preloader");
+  });
 })(jQuery);

--- a/vaso-free/style.css
+++ b/vaso-free/style.css
@@ -48,40 +48,40 @@ CSS STRUCTURE:
 /** 1. VARIABLES
 --------------------------------------------------------------*/
 :root {
-  --accent-color:             #777777;
-  --white-color:              #fff;
-  --black-color:              #151412;
-  --light-dark:               #36332F;
-  --gray-color:               #F3F3F3;
-  --gray-color-300:           #F7F7F7;
-  --gray-color-400:           #EFEFEF;
-  --gray-color-500:           #AEAEAE;
-  --gray-color-600:           #999999;
-  --gray-color-800:           #3A3A3A;
-  --light-gray-color:         #D7DDDF;
-  --primary-color:            #87826E;
-  --bs-primary-rgb:           135,130,110;
-  --light-color:              #f8f9fa;
-  --dark-color:               #212529;
-  --light-blue-color:         #EDF1F3;
-  --navbar-color-color:       #131814;
-  --swiper-theme-color:       #4A4A4A;
-  --swiper-pagination-color:  #4A4A4A;
+  --accent-color: #777777;
+  --white-color: #fff;
+  --black-color: #151412;
+  --light-dark: #36332f;
+  --gray-color: #f3f3f3;
+  --gray-color-300: #f7f7f7;
+  --gray-color-400: #efefef;
+  --gray-color-500: #aeaeae;
+  --gray-color-600: #999999;
+  --gray-color-800: #3a3a3a;
+  --light-gray-color: #d7dddf;
+  --primary-color: #87826e;
+  --bs-primary-rgb: 135, 130, 110;
+  --light-color: #f8f9fa;
+  --dark-color: #212529;
+  --light-blue-color: #edf1f3;
+  --navbar-color-color: #131814;
+  --swiper-theme-color: #4a4a4a;
+  --swiper-pagination-color: #4a4a4a;
 }
 
 /* on mobile devices below 600px
  */
 @media screen and (max-width: 600px) {
-    :root {
-        --header-height : 100px;
-        --header-height-min   : 80px;
-    }
+  :root {
+    --header-height: 100px;
+    --header-height-min: 80px;
+  }
 }
 
 /* Fonts */
 :root {
-    --body-font           : "Mulish", sans-serif;
-    --heading-font        : "Italiana", serif;
+  --body-font: "Mulish", sans-serif;
+  --heading-font: "Italiana", serif;
 }
 
 /*----------------------------------------------*/
@@ -90,7 +90,9 @@ CSS STRUCTURE:
 
 /* 2.1 General Styles
 /*----------------------------------------------*/
-*, *::before, *::after {
+*,
+*::before,
+*::after {
   -webkit-box-sizing: border-box;
   -moz-box-sizing: border-box;
   box-sizing: border-box;
@@ -106,30 +108,35 @@ body {
   line-height: 1.6;
   margin: 0;
 }
-h1,h2,h3,h4,h5,h6 {
+h1,
+h2,
+h3,
+h4,
+h5,
+h6 {
   font-family: var(--heading-font);
   text-transform: capitalize;
   color: var(--black-color);
 }
-h1{
+h1 {
   font-size: 5.5rem;
 }
-h2{
+h2 {
   font-size: 4.5rem;
 }
-h3{
+h3 {
   font-size: 2.625rem;
   line-height: 127%;
 }
-h4{
+h4 {
   font-size: 1.75rem;
   line-height: 127%;
 }
 @media only screen and (max-width: 360px) {
-  h1{
+  h1 {
     font-size: 4.5rem;
   }
-  h2{
+  h2 {
     font-size: 3.5rem;
   }
 }
@@ -159,22 +166,22 @@ a:hover {
   color: var(--primary-color);
 }
 
-.fs-1{
+.fs-1 {
   font-size: 1.75rem !important;
 }
-.fs-2{
+.fs-2 {
   font-size: 1.625rem !important;
 }
-.fs-3{
+.fs-3 {
   font-size: 1.375rem !important;
 }
-.fs-4{
+.fs-4 {
   font-size: 1.25rem !important;
 }
-.fs-5{
+.fs-5 {
   font-size: 1.125rem !important;
 }
-.fs-6{
+.fs-6 {
   font-size: 0.875rem !important;
 }
 
@@ -224,7 +231,7 @@ a:hover {
 
 /* - Section Title
 --------------------------------------------------------------*/
-.title-accent{
+.title-accent {
   color: var(--gray-color-600);
   letter-spacing: 0.14em;
 }
@@ -255,26 +262,26 @@ h5.cart-title {
   box-shadow: none;
 }
 
-.btn-dark{
+.btn-dark {
   color: var(--white-color);
   padding: 10px 22px;
   border: 0;
   transition: 0.3s ease;
 }
-.btn-dark:hover{
+.btn-dark:hover {
   background-color: var(--primary-color);
   color: var(--white-color);
   border: 0;
 }
 
-.btn-primary{
+.btn-primary {
   background-color: var(--primary-color);
   color: var(--white-color);
   padding: 10px 22px;
   border: 0;
   transition: 0.3s ease;
 }
-.btn-primary:hover{
+.btn-primary:hover {
   background-color: var(--black-color);
   color: var(--white-color);
   border: 0;
@@ -282,7 +289,7 @@ h5.cart-title {
 
 /** 2.6 Forms
 --------------------------------------------------------------*/
-label{
+label {
   font-size: 14px;
   font-weight: 600;
   text-transform: uppercase;
@@ -290,7 +297,7 @@ label{
 }
 textarea,
 select,
-input{
+input {
   padding: 8px 0;
   background: none;
   border-top: none;
@@ -324,7 +331,7 @@ input{
   background-color: #f5f3ef;
   overflow: hidden;
 }
-img.zoom-in {  
+img.zoom-in {
   -webkit-transition: 0.6s ease;
   transition: 0.6s ease;
 }
@@ -359,7 +366,9 @@ img.zoom-in {
   z-index: 99999999;
   opacity: 1;
   visibility: visible;
-  transition: opacity 0.3s ease, visibility 0.3s ease;
+  transition:
+    opacity 0.3s ease,
+    visibility 0.3s ease;
 }
 #preloader.hide-preloader {
   opacity: 0;
@@ -392,22 +401,22 @@ img.zoom-in {
 }
 @keyframes lineAnim {
   0% {
-      left: -40%;
+    left: -40%;
   }
   50% {
-      left: 20%;
-      width: 80%;
+    left: 20%;
+    width: 80%;
   }
   100% {
-      left: 100%;
-      width: 100%;
+    left: 100%;
+    width: 100%;
   }
 }
 
 /* - Swiper arrows
 ------------------------------------------------------------- */
 .swiper-buttons .swiper-prev,
-.swiper-buttons .swiper-next{
+.swiper-buttons .swiper-next {
   color: var(--black-color);
   border: 1px solid var(--black-color);
   border-radius: 50%;
@@ -416,32 +425,32 @@ img.zoom-in {
   transition: 0.3s ease;
 }
 .swiper-prev:hover,
-.swiper-next:hover{
+.swiper-next:hover {
   color: var(--white-color);
   background-color: var(--black-color);
 }
 .swiper-prev.swiper-button-disabled,
-.swiper-next.swiper-button-disabled{
+.swiper-next.swiper-button-disabled {
   color: var(--gray-color-500);
   border: 1px solid var(--gray-color-500);
   background: none;
 }
 
-.swiper-buttons span{
+.swiper-buttons span {
   color: var(--gray-color-500);
 }
 .swiper-buttons .swiper-prev.testimonial-arrow-prev,
-.swiper-buttons .swiper-next.testimonial-arrow-next{
+.swiper-buttons .swiper-next.testimonial-arrow-next {
   border: none;
   background: none;
   padding: 0;
 }
 .swiper-prev.testimonial-arrow-prev:hover,
-.swiper-next.testimonial-arrow-next:hover{
+.swiper-next.testimonial-arrow-next:hover {
   color: var(--black-color);
 }
 .swiper-prev.testimonial-arrow-prev.swiper-button-disabled,
-.swiper-next.testimonial-arrow-next.swiper-button-disabled{
+.swiper-next.testimonial-arrow-next.swiper-button-disabled {
   color: var(--gray-color-500);
 }
 
@@ -469,7 +478,7 @@ img.zoom-in {
   right: 0;
   background: none;
   z-index: 3;
-  transition: width .4s cubic-bezier(0.000, 0.795, 0.000, 1.000);
+  transition: width 0.4s cubic-bezier(0, 0.795, 0, 1);
   cursor: pointer;
 }
 #search-bar input[type="text"]:focus:hover {
@@ -494,7 +503,7 @@ img.zoom-in {
   z-index: 999999;
   transition: background-color 0.3s ease;
 }
-.site-header.sticky{
+.site-header.sticky {
   background-color: var(--white-color);
 }
 .navbar-toggler svg.navbar-icon {
@@ -511,7 +520,7 @@ img.zoom-in {
   color: var(--accent-color);
 }
 .dropdown-toggle::after {
-  display: none;  
+  display: none;
 }
 /*------------ Offcanvas -------------- */
 #header-nav .navbar-toggler:focus {
@@ -526,20 +535,20 @@ img.zoom-in {
   border: none;
 }
 .offcanvas.show .offcanvas-body .navbar-nav {
-  align-items: unset!important;
+  align-items: unset !important;
 }
-.offcanvas-body .dropdown-menu{
+.offcanvas-body .dropdown-menu {
   min-width: 13rem;
   background-color: var(--gray-color-300);
   border: 1px solid var(--gray-color-500);
   border-radius: 0;
 }
-.offcanvas-body .dropdown-menu .dropdown-item{
+.offcanvas-body .dropdown-menu .dropdown-item {
   color: var(--black-color);
 }
 .offcanvas-body .dropdown-menu .dropdown-item.active,
 .offcanvas-body .dropdown-menu .dropdown-item:hover,
-.offcanvas-body .dropdown-menu .dropdown-item:focus{
+.offcanvas-body .dropdown-menu .dropdown-item:focus {
   background: none;
   color: var(--accent-color);
 }
@@ -558,32 +567,34 @@ img.zoom-in {
   .navbar-nav .nav-item a.nav-link {
     margin-right: 40px;
     margin-left: 40px;
-  }  
+  }
 }
 @media only screen and (max-width: 991px) {
   .navbar-nav .nav-item a.nav-link {
     margin-right: 0;
     margin-left: 0;
-  }  
+  }
 }
 
 /* 3.2 Billboard
 /*----------------------------------------------*/
-.banner-content{
+.banner-content {
   margin-top: 60%;
 }
-.swiper-slide .banner-content{
-  opacity: 0;  
+.swiper-slide .banner-content {
+  opacity: 0;
   transition: opacity 1.5s ease-in-out;
 }
-.swiper-slide-active .banner-content{
+.swiper-slide-active .banner-content {
   opacity: 1;
 }
 #billboard .main-slider-pagination {
   z-index: 999;
   bottom: 62px;
 }
-.swiper-horizontal>.swiper-pagination-bullets .swiper-pagination-bullet, .swiper-pagination-horizontal.swiper-pagination-bullets .swiper-pagination-bullet{
+.swiper-horizontal > .swiper-pagination-bullets .swiper-pagination-bullet,
+.swiper-pagination-horizontal.swiper-pagination-bullets
+  .swiper-pagination-bullet {
   background-color: var(--gray-color-400);
   opacity: 0.9;
   width: 18px;
@@ -591,7 +602,11 @@ img.zoom-in {
   margin: 0 13px !important;
   transition: 0.3s ease;
 }
-.swiper-horizontal>.swiper-pagination-bullets .swiper-pagination-bullet.swiper-pagination-bullet-active, .swiper-pagination-horizontal.swiper-pagination-bullets .swiper-pagination-bullet.swiper-pagination-bullet-active{
+.swiper-horizontal
+  > .swiper-pagination-bullets
+  .swiper-pagination-bullet.swiper-pagination-bullet-active,
+.swiper-pagination-horizontal.swiper-pagination-bullets
+  .swiper-pagination-bullet.swiper-pagination-bullet-active {
   background-color: var(--black-color);
   opacity: 1;
 }
@@ -619,7 +634,7 @@ img.zoom-in {
 
 /* 3.4 Video
 /*----------------------------------------------*/
-.video-section.jarallax{
+.video-section.jarallax {
   min-height: 825px;
 }
 /* overide */
@@ -634,7 +649,7 @@ img.zoom-in {
   padding: 0;
   background-color: #f5f3ef;
   border: none;
-  border-radius: 0
+  border-radius: 0;
 }
 .text-pattern {
   animation: rotation 50s infinite linear;
@@ -650,10 +665,10 @@ img.zoom-in {
 
 /* 3.5 FAQs
 /*----------------------------------------------*/
-.accordion-item{
+.accordion-item {
   background: none;
 }
-.accordion-button{
+.accordion-button {
   background: none;
   font-size: 1.75rem;
   line-height: 127%;
@@ -673,7 +688,7 @@ img.zoom-in {
   background-image: url("data:image/svg+xml,%3csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 16 16' fill='%23212529'%3e%3cpath fill-rule='evenodd' d='M1.646 4.646a.5.5 0 0 1 .708 0L8 10.293l5.646-5.647a.5.5 0 0 1 .708.708l-6 6a.5.5 0 0 1-.708 0l-6-6a.5.5 0 0 1 0-.708z'/%3e%3c/svg%3e");
   transform: rotate(-180deg);
 }
-.accordion-body{
+.accordion-body {
   padding-top: 0;
 }
 
@@ -687,16 +702,22 @@ img.zoom-in {
   grid-row-gap: 20px;
   height: 90vh;
 }
-.banner-content-1 { grid-area: 1 / 1 / 3 / 2; }
-.banner-content-2 { grid-area: 1 / 2 / 2 / 3; }
-.banner-content-3 { grid-area: 2 / 2 / 3 / 3; }
-.banner-content-text{
+.banner-content-1 {
+  grid-area: 1 / 1 / 3 / 2;
+}
+.banner-content-2 {
+  grid-area: 1 / 2 / 2 / 3;
+}
+.banner-content-3 {
+  grid-area: 2 / 2 / 3 / 3;
+}
+.banner-content-text {
   left: 10%;
   bottom: 16%;
 }
 #banner.aos-init.aos-animate .banner-content-1,
 #banner.aos-init.aos-animate .banner-content-2,
-#banner.aos-init.aos-animate .banner-content-3{
+#banner.aos-init.aos-animate .banner-content-3 {
   animation: parallax 1s ease-in-out forwards;
 }
 @keyframes parallax {
@@ -712,10 +733,16 @@ img.zoom-in {
     grid-template-columns: 1fr;
     grid-template-rows: repeat(3, 1fr);
     height: 140vh;
-  }  
-  .banner-content-1 { grid-area: 1 / 1 / 2 / 2; }
-  .banner-content-2 { grid-area: 2 / 1 / 3 / 2; }
-  .banner-content-3 { grid-area: 3 / 1 / 4 / 2; }
+  }
+  .banner-content-1 {
+    grid-area: 1 / 1 / 2 / 2;
+  }
+  .banner-content-2 {
+    grid-area: 2 / 1 / 3 / 2;
+  }
+  .banner-content-3 {
+    grid-area: 3 / 1 / 4 / 2;
+  }
 }
 
 /* 3.7 Footer
@@ -739,15 +766,15 @@ img.zoom-in {
 
 /* 4.1 About Us Page
 /*----------------------------------------------*/
-#about .about-content{
+#about .about-content {
   position: absolute;
   min-width: 50%;
   min-height: fit-content;
   max-height: fit-content;
   padding: 60px;
-  background-color: var(--gray-color-300);  
+  background-color: var(--gray-color-300);
 }
-#about.aos-init.aos-animate img.single-image{
+#about.aos-init.aos-animate img.single-image {
   animation: parallax 0.8s ease-in-out forwards;
 }
 @keyframes parallax {
@@ -759,25 +786,25 @@ img.zoom-in {
   }
 }
 @media only screen and (max-width: 1200px) {
-  #about .about-content{
+  #about .about-content {
     min-width: 70%;
   }
 }
 @media only screen and (max-width: 991px) {
-  #about .about-content{
+  #about .about-content {
     position: unset;
     padding: 40px;
   }
 }
 
 /* Newsletter */
-#newsletter .form-control{
+#newsletter .form-control {
   font-size: inherit;
 }
-#newsletter form input{
+#newsletter form input {
   background: none;
 }
-#newsletter form input:focus{
+#newsletter form input:focus {
   box-shadow: none;
 }
 
@@ -812,7 +839,7 @@ h5.widget-title {
 /* 4.3 Single Product Page
 /*----------------------------------------------*/
 /*---- Single Product Image ----------*/
-.single-product .large-swiper{
+.single-product .large-swiper {
   padding-left: 0;
 }
 .product-preview .swiper-slide {
@@ -820,15 +847,15 @@ h5.widget-title {
   padding-bottom: 10px;
   transition: cubic-bezier(0.22, 0.78, 0.71, 1.01);
 }
-.swiper-slide-thumb-active img{
+.swiper-slide-thumb-active img {
   border: 1px solid var(--accent-color);
 }
 
 /*---- Single Product Information ----------*/
-.product-info del{
+.product-info del {
   color: var(--gray-color-500);
 }
-.product-info hr{
+.product-info hr {
   color: var(--gray-color-500);
 }
 .rating-container .rating {
@@ -840,14 +867,14 @@ h5.widget-title {
   font-size: 1.6em;
   padding-right: 10px;
 }
-.product-info .select-item{
+.product-info .select-item {
   margin-right: 8px;
 }
-.input-group{
+.input-group {
   padding: 6px;
   background-color: var(--gray-color-400);
 }
-.input-group button{
+.input-group button {
   border: none;
 }
 
@@ -859,7 +886,7 @@ h5.widget-title {
   color: var(--black-color);
   font-weight: 600;
 }
-.nav-tabs .nav-link:focus{
+.nav-tabs .nav-link:focus {
   box-shadow: none;
 }
 .nav-tabs .nav-link {
@@ -877,24 +904,24 @@ h5.widget-title {
   border-bottom: 1px solid var(--black-color);
   padding: 40px 0;
 }
-.product-tabs .review-item{
+.product-tabs .review-item {
   width: 50%;
   margin-bottom: 20px;
 }
-.product-tabs .review-item .image-holder{
+.product-tabs .review-item .image-holder {
   margin-right: 10px;
 }
 @media screen and (max-width: 991px) {
-  .product-tabs .review-item{
+  .product-tabs .review-item {
     width: 100%;
     flex-wrap: wrap;
   }
-  .product-tabs .review-item .image-holder{
+  .product-tabs .review-item .image-holder {
     margin-bottom: 10px;
   }
 }
 @media screen and (max-width: 991px) {
-  .cart-header{
+  .cart-header {
     display: none;
   }
 }
@@ -902,25 +929,25 @@ h5.widget-title {
 /* 4.4 Cart Page
 -----------------------------------------------------*/
 .shopify-cart .table th {
-    width: 36%;
+  width: 36%;
 }
-.table>:not(caption)>*>*{
+.table > :not(caption) > * > * {
   padding: 1.5rem;
 }
-.shopify-cart .cart-product-detail{
+.shopify-cart .cart-product-detail {
   max-width: 250px;
 }
 @media screen and (max-width: 775px) {
-  .shopify-cart .table thead{
+  .shopify-cart .table thead {
     display: none;
   }
-  .shopify-cart .table tbody{
+  .shopify-cart .table tbody {
     border: none;
   }
-  .shopify-cart .table tbody td{
+  .shopify-cart .table tbody td {
     display: block;
   }
-  .table>:not(caption)>*>*{
+  .table > :not(caption) > * > * {
     padding: 1rem;
   }
 }
@@ -928,7 +955,7 @@ h5.widget-title {
 /* 4.5 Blog Page
 --------------------------------------------------------------*/
 /*------------ Sidebar -----------*/
-.widget.sidebar-recent-post .card-image{
+.widget.sidebar-recent-post .card-image {
   max-width: 120px;
 }
 .sidebar-post-item h4.card-title {


### PR DESCRIPTION
## Summary
- escape ampersands in Google Fonts URL to keep HTML valid
- guard Swiper, Jarallax, and AOS calls so the page still renders when plugins are missing

## Testing
- `npx prettier vaso-free/style.css vaso-free/index.html vaso-free/js/script.js --check`
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_b_68af2d5780448320ba94ae7f95b3d7b4