### PR TITLE
Ensure home sections display without AOS

### DIFF
--- a/client/app/[lang]/page.js
+++ b/client/app/[lang]/page.js
@@ -2,6 +2,7 @@ import { loadSiteFragment } from '../../src/lib/loadSiteFragment';
 import { getPage, getProducts } from '../../src/lib/content';
 import dynamic from 'next/dynamic';
 import VideoStrip from '../../src/components/home/VideoStrip';
+import AOSFallback from '../../src/components/AOSFallback';
 
 // Render carousels client‑side only to avoid SSR/CSR timing issues
 const Hero = dynamic(() => import('../../src/components/home/Hero'), { ssr: false });
@@ -28,6 +29,7 @@ export default async function LocaleHome({ params }){
       <Hero title={data?.title || 'Kapunka'} subtitle={data?.subtitle || ''} />
       {/* Best‑Sellers temporarily removed for stability */}
       <main dangerouslySetInnerHTML={{ __html: html }} />
+      <AOSFallback />
       <VideoStrip />
     </>
   );

--- a/client/src/components/AOSFallback.js
+++ b/client/src/components/AOSFallback.js
@@ -1,0 +1,15 @@
+'use client';
+
+import { useEffect } from 'react';
+
+export default function AOSFallback(){
+  useEffect(() => {
+    if (typeof window !== 'undefined' && !window.AOS) {
+      document.querySelectorAll('[data-aos]').forEach(el => {
+        el.classList.add('aos-animate');
+        el.style.opacity = '1';
+      });
+    }
+  }, []);
+  return null;
+}


### PR DESCRIPTION
## Summary
- add `AOSFallback` to reveal elements marked with `data-aos` when the AOS library is absent
- integrate fallback into the localized home page to render static sections again

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_68c46a8212688320a8d03bec266904bc